### PR TITLE
Mark as client-side only

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -15,7 +15,7 @@
 	},
 	"license" : "LGPL-3.0-only",
 	"icon" : "assets/dashloader/textures/icon.png",
-	"environment" : "*",
+	"environment" : "client",
 	"accessWidener" : "dashloader.accesswidener",
 	"mixins" : [
 		"dashloader.mixins.json"


### PR DESCRIPTION
According to the modrinth page, the mod is client-side only. However, it's not marked like that in the mod's json, making fabric load it in dedicated servers, and preventing it from being marked as client-side by mods that read the metadata (such as ModMenu). This PR changes that.

The new line at the end of the file is caused by the github editor always adding it (I didn't clone the whole repo just for this change). Feel free to manually apply the changes if you don't want it.