### PR TITLE
Better ANSI escape codes for text color in logs.

### DIFF
--- a/src/main/java/dev/notalpha/dashloader/Cache.java
+++ b/src/main/java/dev/notalpha/dashloader/Cache.java
@@ -217,7 +217,7 @@ public final class Cache {
 	public void setStatus(Status status) {
 		if (this.status != status) {
 			this.status = status;
-			DashLoader.LOG.info("\u001B[46m\u001B[30m DashLoader Status change {}\n\u001B[0m", status);
+			DashLoader.LOG.info("\u001B[46;30m DashLoader Status change {}\n\u001B[49;39m", status);
 			this.cacheHandlers.forEach(handler -> handler.reset(this));
 		}
 	}


### PR DESCRIPTION
* Merged `\e[46m\e[30m` into one escape code, `\e[46;30m`.
* Replaced `\e[0m` with `\e[49;39m`, which should only reset the foreground and background colors, and nothing else (e.g. bold, underline, etc).