### PR TITLE
check if cache is null due to earlier reloads from other mods

### DIFF
--- a/src/main/java/dev/notalpha/dashloader/mixin/main/ReloadableResourceManagerImplMixin.java
+++ b/src/main/java/dev/notalpha/dashloader/mixin/main/ReloadableResourceManagerImplMixin.java
@@ -52,6 +52,8 @@ public class ReloadableResourceManagerImplMixin {
 
 		String hash = DigestUtils.md5Hex(values.toString()).toUpperCase();
 		DashLoader.LOG.info("Hash changed to {}", hash);
-		DashLoaderClient.CACHE.load(hash);
+        if (DashLoaderClient.CACHE != null) {
+            DashLoaderClient.CACHE.load(hash);
+        }
 	}
 }


### PR DESCRIPTION
fixes #111 
simple if check for null or non-existent CACHE from a missing dashloader-cache folder during a very earlier reload from mods like moonlight and blueprint in a highly modded instance.

shows that moonlight and blueprint loaded assets before dashloader
```
[18Aug2025 11:50:45.904] [Render thread/INFO][Moonlight/]: Generated runtime resources for 7 packs in a total of: 681 ms
[18Aug2025 11:50:45.968] [Render thread/INFO][com.teamabnormals.blueprint.core.Blueprint/]: Successfully loaded 0 assets remolders!
[18Aug2025 11:50:45.972] [Render thread/INFO][DashLoader/]: Hash changed to C399D6064103E58083E9F5356F787A38
[18Aug2025 11:50:46.690] [Render thread/FATAL][net.neoforged.neoforge.common.NeoForgeMod/]: Preparing crash report with UUID 2def3bb5-7b25-43d7-bb44-61fb7c94292a
[18Aug2025 11:50:46.693] [Render thread/INFO][STDOUT/]: [net.minecraft.server.Bootstrap:realStdoutPrintln:135]: ---- Minecraft Crash Report ----
```

show the crash that occurs

```
java.lang.ExceptionInInitializerError: null
at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.packs.resources.ReloadableResourceManager.handler$flp000$dashloader$reloadDash(ReloadableResourceManager.java:2555) ~[client-1.21.1-20240808.144430-srg.jar%231409!/:?] {re:mixin,pl:accesstransformer:B,pl:connector_pre_launch:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:chunksfadein.mixins.json:misc.ReloadableResourceManagerMixin from mod chunksfadein,pl:mixin:APP:pfm.mixins.json:PFMReloadableResourceManagerImplMixin from mod pfm,pl:mixin:APP:pfm-common.mixins.json:PFMReloadableResourceManagerImplMixin from mod pfm,pl:mixin:APP:mixson.mixins.json:ResourceManagerImplMixinArray from mod mixson,pl:mixin:APP:dashloader.mixins.json:main.ReloadableResourceManagerImplMixin from mod dashloader,pl:mixin:APP:continuity.mixins.json:ReloadableResourceManagerImplAccessor from mod continuity,pl:mixin:APP:blueprint.mixins.json:client.ReloadableResourceManagerMixin from mod blueprint,pl:mixin:A,pl:connector_pre_launch:A}
at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.packs.resources.ReloadableResourceManager.createReload(ReloadableResourceManager.java:44) ~[client-1.21.1-20240808.144430-srg.jar%231409!/:?] {re:mixin,pl:accesstransformer:B,pl:connector_pre_launch:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:chunksfadein.mixins.json:misc.ReloadableResourceManagerMixin from mod chunksfadein,pl:mixin:APP:pfm.mixins.json:PFMReloadableResourceManagerImplMixin from mod pfm,pl:mixin:APP:pfm-common.mixins.json:PFMReloadableResourceManagerImplMixin from mod pfm,pl:mixin:APP:mixson.mixins.json:ResourceManagerImplMixinArray from mod mixson,pl:mixin:APP:dashloader.mixins.json:main.ReloadableResourceManagerImplMixin from mod dashloader,pl:mixin:APP:continuity.mixins.json:ReloadableResourceManagerImplAccessor from mod continuity,pl:mixin:APP:blueprint.mixins.json:client.ReloadableResourceManagerMixin from mod blueprint,pl:mixin:A,pl:connector_pre_launch:A}
at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.Minecraft.<init>(Unknown Source) ~[client-1.21.1-20240808.144430-srg.jar%231409!/:?] {re:mixin,pl:accesstransformer:B,pl:connector_pre_launch:A,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:owo.mixins.json:MinecraftClientMixin from mod owo,pl:mixin:APP:modernfix-common.mixins.json:bugfix.world_leaks.MinecraftMixin from mod modernfix,pl:mixin:APP:modernfix-common.mixins.json:bugfix.concurrency.MinecraftMixin from mod modernfix,pl:mixin:APP:modernfix-common.mixins.json:feature.measure_time.MinecraftMixin from mod modernfix,pl:mixin:APP:modernfix-common.mixins.json:perf.dedicated_reload_executor.MinecraftMixin from mod modernfix,pl:mixin:APP:modernfix-neoforge.mixins.json:feature.measure_time.MinecraftMixin_Forge from mod modernfix,pl:mixin:APP:supplementaries-common.mixins.json:MinecraftMixin from mod supplementaries,pl:mixin:APP:mixins.mekanism_weaponry.json:MinecraftMixin from mod mekanism_weaponry,pl:mixin:APP:wover.event.mixins.client.json:startup_screen.MinecraftMixin from mod wover_events,pl:mixin:APP:accessories-common.mixins.json:client.MinecraftMixin from mod accessories,pl:mixin:APP:cumulus_menus.mixins.json:client.accessor.MinecraftAccessor from mod cumulus_menus,pl:mixin:APP:chunksfadein.mixins.json:misc.MinecraftMixin from mod chunksfadein,pl:mixin:APP:confluence.mixins.json:client.MinecraftMixin from mod confluence,pl:mixin:APP:beautiful_potions.mixins.json:test.TestMixin from mod beautiful_potions,pl:mixin:APP:beautiful_potions-common.mixins.json:test.TestMixin from mod beautiful_potions,pl:mixin:APP:xkdeco.mixins.json:client.MinecraftMixin from mod xkdeco,pl:mixin:APP:tickrateapi.mixin.json:MixinMinecraft from mod tickrateapi,pl:mixin:APP:glassential.mixins.json:MixinMinecraft from mod glassential,pl:mixin:APP:konkrete.mixins.json:client.MixinMinecraft from mod konkrete,pl:mixin:APP:entity_texture_features-common.mixins.json:reloading.MixinMinecraftClient from mod entity_texture_features,pl:mixin:APP:entity_texture_features-common.mixins.json:reloading.MixinResourceReload from mod entity_texture_features,pl:mixin:APP:neoforge-stackable_stew_and_soup.mixins.json:MinecraftMixin from mod stackable_stew_and_soup,pl:mixin:APP:entity_sound_features-common.mixins.json:MixinResourceReload from mod entity_sound_features,pl:mixin:APP:combatnouveau.common.mixins.json:client.MinecraftMixin from mod combatnouveau,pl:mixin:APP:ichunutil.mixins.json:client.MinecraftMixin from mod ichunutil,pl:mixin:APP:azurelib.neo.mixins.json:MinecraftMixin from mod azurelib,pl:mixin:APP:factory_api.mixins.json:MinecraftMixin from mod factory_api,pl:mixin:APP:just_enough_beacons.mixins.json:test.TestMixin from mod just_enough_beacons,pl:mixin:APP:just_enough_beacons-common.mixins.json:test.TestMixin from mod just_enough_beacons,pl:mixin:APP:fabric-screen-api-v1.mixins.json:MinecraftClientMixin from mod fabric_screen_api_v1,pl:mixin:APP:resourcefulconfig.mixins.json:client.MinecraftMixin from mod resourcefulconfig,pl:mixin:APP:paginatedadvancements.mixins.json:MinecraftClientMixin from mod paginatedadvancements,pl:mixin:APP:mekanismcovers.mixins.json:MinecraftMixin from mod mekanismcovers,pl:mixin:APP:glitchcore.mixins.json:client.MixinMinecraft from mod glitchcore,pl:mixin:APP:polytone-common.mixins.json:MinecraftMixin from mod polytone,pl:mixin:APP:immersiveengineering.mixins.json:accessors.client.MinecraftAccess from mod immersiveengineering,pl:mixin:APP:dashloader.mixins.json:main.MinecraftClientMixin from mod dashloader,pl:mixin:APP:unionlib.mixins.json:client.MinecraftMixin from mod unionlib,pl:mixin:APP:aether.mixins.json:client.accessor.MinecraftAccessor from mod aether,pl:mixin:APP:fcb.mixins.json:MinecraftMixin from mod fcb,pl:mixin:APP:memoryusagetitle-common.mixins.json:MinecraftClientMixin from mod memoryusagetitle,pl:mixin:APP:blastingclay.mixins.json:MixinMinecraft from mod blastingclay,pl:mixin:APP:architectury.mixins.json:MixinMinecraft from mod architectury,pl:mixin:APP:fabric-networking-api-v1.client.mixins.json:accessor.MinecraftClientAccessor from mod fabric_networking_api_v1,pl:mixin:APP:fabric-lifecycle-events-v1.client.mixins.json:MinecraftClientMixin from mod fabric_lifecycle_events_v1,pl:mixin:APP:better_beacons.mixins.json:test.TestMixin from mod better_beacons,pl:mixin:APP:better_beacons-common.mixins.json:test.TestMixin from mod better_beacons,pl:mixin:APP:cryonicconfig.mixins.json:client.MinecraftMixin from mod cryonicconfig,pl:mixin:APP:yacl.mixins.json:MinecraftMixin from mod yet_another_config_lib_v3,pl:mixin:APP:neoforge-healthy_water.mixins.json:MinecraftMixin from mod healthy_water,pl:mixin:APP:mixins.hammerlib.json:client.MinecraftMixin from mod hammerlib,pl:mixin:APP:mixins.iris.json:MixinMinecraft_Images from mod iris,pl:mixin:APP:mixins.iris.json:MixinMinecraft_Keybinds from mod iris,pl:mixin:APP:mixins.iris.json:MixinMinecraft_PipelineManagement from mod iris,pl:mixin:APP:terra_curio.mixins.json:client.accessor.MinecraftAccessor from mod terra_curio,pl:mixin:APP:pickupnotifier.common.mixins.json:client.MinecraftMixin from mod pickupnotifier,pl:mixin:APP:startuptime.mixins.json:MinecraftMixin from mod startuptime,pl:mixin:APP:transition.mixins.json:EntityRenderStateMixin from mod transition,pl:mixin:APP:transition.mixins.json:EntityRendererMixin from mod transition,pl:mixin:APP:the_bumblezone-common.mixins.json:client.MinecraftMixin from mod the_bumblezone,pl:mixin:APP:lithium-neoforge.mixins.json:startup.MinecraftMixin from mod lithium,pl:mixin:APP:laserbridges.mixins.json:MixinMinecraft from mod laserbridges,pl:mixin:APP:champions.mixins.json:MinecraftMixin from mod champions,pl:mixin:APP:sodium-common.mixins.json:core.MinecraftMixin from mod sodium,pl:mixin:APP:sodium-neoforge.mixins.json:platform.neoforge.EntrypointMixin from mod sodium,pl:mixin:APP:chloride.mixin.json:MinecraftMixin from mod chloride,pl:mixin:APP:chloride.mixin.json:OverlayMixin from mod chloride,pl:mixin:APP:alltheleaks.mixins.json:main.MinecraftMixin from mod alltheleaks,pl:mixin:APP:alltheleaks.mixins.json:main.MinecraftMixin2 from mod alltheleaks,pl:mixin:APP:particlestorm.mixins.json:MinecraftMixin from mod particlestorm,pl:mixin:APP:notenoughanimations.mixins.json:LivingRenderStateMixin from mod notenoughanimations,pl:mixin:APP:flywheel.impl.mixins.json:MinecraftMixin from mod flywheel,pl:mixin:APP:neoforge-golden_foods.mixins.json:MinecraftMixin from mod golden_foods,pl:mixin:APP:prism.mixins.json:MinecraftMixin from mod prism,pl:mixin:APP:bookshelf.mixins.json:access.client.AccessorMinecraft from mod bookshelf,pl:mixin:APP:carryon.mixins.json:MinecraftMixin from mod carryon,pl:mixin:APP:mixins.connectorextras_modmenu_bridge.json:MinecraftMixin from mod connectorextras_modmenu_bridge,pl:mixin:APP:entity_model_features-common.mixins.json:MixinResourceReloadEnd from mod entity_model_features,pl:mixin:APP:entity_model_features-common.mixins.json:MixinResourceReloadStart from mod entity_model_features,pl:mixin:APP:entity_model_features-common.mixins.json:accessor.MinecraftClientAccessor from mod entity_model_features,pl:mixin:APP:mixins.ipnext.json:MixinMinecraftClient from mod inventoryprofilesnext,pl:mixin:APP:blastingsand.mixins.json:MixinMinecraft from mod blastingsand,pl:mixin:APP:l2menustacker.mixins.json:MinecraftMixin from mod l2menustacker,pl:mixin:APP:fancymenu.mixins.json:client.IMixinMinecraft from mod fancymenu,pl:mixin:APP:fancymenu.mixins.json:client.MixinMinecraft from mod fancymenu,pl:mixin:APP:sodium-extra.mixins.json:core.MixinMinecraftClient from mod sodium_extra,pl:mixin:APP:sodium-extra.mixins.json:gui.MinecraftClientAccessor from mod sodium_extra,pl:mixin:APP:bettercombat.mixins.json:client.MinecraftClientAccessor from mod bettercombat,pl:mixin:APP:bettercombat.mixins.json:client.MinecraftClientInject from mod bettercombat,pl:mixin:APP:ponder-common.mixins.json:client.WindowResizeMixin from mod ponder,pl:mixin:APP:betternether.mixins.client.json:MinecraftClientMixin from mod betternether,pl:mixin:APP:balm.neoforge.mixins.json:MinecraftMixin from mod balm,pl:mixin:APP:sodiumextrainformation.mixins.json:EndTickMixin from mod sodiumextrainformation,pl:mixin:APP:sodiumextrainformation-neoforge.mixin.json:EntrypointMixin from mod sodiumextrainformation,pl:mixin:APP:eternal_starlight-common.mixins.json:client.MinecraftMixin from mod eternal_starlight,pl:mixin:APP:carpet.mixins.json:Minecraft_tickMixin from mod carpet,pl:mixin:APP:carpet.mixins.json:MinecraftMixin from mod carpet,pl:mixin:APP:mixins/common/nochatreports.mixins.json:client.MixinMinecraft from mod nochatreports,pl:mixin:APP:bigshot.mixins.json:MixinMinecraft from mod bigshot,pl:mixin:APP:ctrlq.mixins.json:MixinMinecraft from mod ctrlq,pl:mixin:APP:ars_nouveau.mixins.json:light.ClientMixin from mod ars_nouveau,pl:mixin:APP:bankstorage.client.mixins.json:ItemPickMixin from mod bankstorage,pl:mixin:APP:bclib.mixins.client.json:MinecraftMixin from mod bclib,pl:mixin:APP:owo.mixins.json:ui.MinecraftClientMixin from mod owo,pl:mixin:APP:journeymap.mixins.json:client.MinecraftMixin from mod journeymap,pl:mixin:APP:blueprint.mixins.json:client.MinecraftMixin from mod blueprint,pl:mixin:APP:moonlight-common.mixins.json:MinecraftMixin from mod moonlight,pl:mixin:APP:configuration.mixins.json:MinecraftMixin from mod configuration,pl:mixin:APP:ae2.mixins.json:PickColorMixin from mod ae2,pl:mixin:APP:ae2wtlib.mixins.json:MinecraftMixin from mod ae2wtlib,pl:mixin:APP:platform.mixins.json:client.MinecraftMixin from mod platform,pl:mixin:APP:platform-common.mixins.json:client.MinecraftMixin from mod platform,pl:mixin:APP:forbidden_arcanus.mixins.json:client.MinecraftMixin from mod forbidden_arcanus,pl:mixin:APP:iceberg.mixins.json:MinecraftMixin from mod iceberg,pl:mixin:APP:blastingstone.mixins.json:MixinMinecraft from mod blastingstone,pl:mixin:APP:fabric-events-interaction-v0.client.mixins.json:MinecraftClientMixin from mod fabric_events_interaction_v0,pl:mixin:APP:craterlib.mixins.json:events.client.MinecraftMixin from mod (unknown),pl:mixin:APP:sound_physics_remastered.mixins.json:MinecraftMixin from mod (unknown),pl:mixin:APP:mixins.codechickenlib.json:MinecraftMixin from mod (unknown),pl:mixin:APP:create.mixins.json:accessor.MinecraftAccessor from mod create,pl:mixin:APP:modernfix-common.mixins.json:feature.remove_telemetry.MinecraftMixin_Telemetry from mod modernfix,pl:mixin:APP:securitycraft.mixins.json:camera.MinecraftMixin from mod securitycraft,pl:mixin:APP:ars_nouveau.mixins.json:camera.MinecraftMixin from mod ars_nouveau,pl:mixin:APP:connector.mixins.json:boot.MinecraftMixin from mod connector,pl:mixin:A,pl:connector_pre_launch:A,pl:runtimedistcleaner:A}
at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.main.Main.main(Main.java:214) ~[client-1.21.1-20240808.144430-srg.jar%231409!/:?] {re:mixin,pl:connector_pre_launch:A,pl:runtimedistcleaner:A,re:classloading,pl:mixin:APP:threadtweak.mixins.json:client.MainMixin from mod threadtweak,pl:mixin:APP:dashloader.mixins.json:main.MainMixin from mod dashloader,pl:mixin:APP:cryonicconfig.mixins.json:client.MainMixin from mod cryonicconfig,pl:mixin:A,pl:connector_pre_launch:A,pl:runtimedistcleaner:A}
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[?:?] {}
at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[?:?] {re:mixin}
at MC-BOOTSTRAP/fml_loader@4.0.41/net.neoforged.fml.loading.targets.CommonLaunchHandler.runTarget(CommonLaunchHandler.java:136) ~[loader-4.0.41.jar%23107!/:4.0] {}
at MC-BOOTSTRAP/fml_loader@4.0.41/net.neoforged.fml.loading.targets.CommonLaunchHandler.clientService(CommonLaunchHandler.java:124) ~[loader-4.0.41.jar%23107!/:4.0] {}
at MC-BOOTSTRAP/fml_loader@4.0.41/net.neoforged.fml.loading.targets.CommonClientLaunchHandler.runService(CommonClientLaunchHandler.java:32) ~[loader-4.0.41.jar%23107!/:4.0] {}
at MC-BOOTSTRAP/fml_loader@4.0.41/net.neoforged.fml.loading.targets.CommonLaunchHandler.lambda$launchService$4(CommonLaunchHandler.java:118) ~[loader-4.0.41.jar%23107!/:4.0] {}
at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.LaunchServiceHandlerDecorator.launch(LaunchServiceHandlerDecorator.java:30) [modlauncher-11.0.5.jar%23112!/:?] {}
at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:53) [modlauncher-11.0.5.jar%23112!/:?] {}
at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:71) [modlauncher-11.0.5.jar%23112!/:?] {}
at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.Launcher.run(Launcher.java:103) [modlauncher-11.0.5.jar%23112!/:?] {}
at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.Launcher.main(Launcher.java:74) [modlauncher-11.0.5.jar%23112!/:?] {}
at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:26) [modlauncher-11.0.5.jar%23112!/:?] {}
at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.5/cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:23) [modlauncher-11.0.5.jar%23112!/:?] {}
at cpw.mods.bootstraplauncher@2.0.2/cpw.mods.bootstraplauncher.BootstrapLauncher.run(BootstrapLauncher.java:210) [bootstraplauncher-2.0.2.jar:?] {}
at cpw.mods.bootstraplauncher@2.0.2/cpw.mods.bootstraplauncher.BootstrapLauncher.main(BootstrapLauncher.java:69) [bootstraplauncher-2.0.2.jar:?] {}
Caused by: dev.notalpha.hyphen.thr.HyphenException: net.minecraft.client.renderer.block.model.ItemTransform.<init>(org.joml.Vector3f,org.joml.Vector3f,org.joml.Vector3f,org.joml.Vector3f,boolean,boolean,boolean,boolean,float,float,float,float)
at TRANSFORMER/dashloader.beta._8._1._21._1.Hyphen.rc._5.mapped.moj._1._21._1@5.1.0-beta.8+1.21.1$Hyphen-0.4.0-rc.5_mapped_moj_1.21.1/dev.notalpha.hyphen.codegen.def.ClassDef.scan(ClassDef.java:90) ~[dashloader-5.1.0-beta.8+1.21.1$Hyphen-0.4.0-rc.5_mapped_moj_1.21.1.jar%234527!/:?] {re:classloading}
at TRANSFORMER/dashloader.beta._8._1._21._1.Hyphen.rc._5.mapped.moj._1._21._1@5.1.0-beta.8+1.21.1$Hyphen-0.4.0-rc.5_mapped_moj_1.21.1/dev.notalpha.hyphen.SerializerGenerator.acquireDef(SerializerGenerator.java:140) ~[dashloader-5.1.0-beta.8+1.21.1$Hyphen-0.4.0-rc.5_mapped_moj_1.21.1.jar%234527!/:?] {re:classloading}
at TRANSFORMER/dashloader.beta._8._1._21._1.Hyphen.rc._5.mapped.moj._1._21._1@5.1.0-beta.8+1.21.1$Hyphen-0.4.0-rc.5_mapped_moj_1.21.1/dev.notalpha.hyphen.codegen.def.ClassDef.scan(ClassDef.java:47) ~[dashloader-5.1.0-beta.8+1.21.1$Hyphen-0.4.0-rc.5_mapped_moj_1.21.1.jar%234527!/:?] {re:classloading}
at TRANSFORMER/dashloader.beta._8._1._21._1.Hyphen.rc._5.mapped.moj._1._21._1@5.1.0-beta.8+1.21.1$Hyphen-0.4.0-rc.5_mapped_moj_1.21.1/dev.notalpha.hyphen.SerializerGenerator.acquireDef(SerializerGenerator.java:140) ~[dashloader-5.1.0-beta.8+1.21.1$Hyphen-0.4.0-rc.5_mapped_moj_1.21.1.jar%234527!/:?] {re:classloading}
at TRANSFORMER/dashloader.beta._8._1._21._1.Hyphen.rc._5.mapped.moj._1._21._1@5.1.0-beta.8+1.21.1$Hyphen-0.4.0-rc.5_mapped_moj_1.21.1/dev.notalpha.hyphen.codegen.def.ClassDef.scan(ClassDef.java:47) ~[dashloader-5.1.0-beta.8+1.21.1$Hyphen-0.4.0-rc.5_mapped_moj_1.21.1.jar%234527!/:?] {re:classloading}
at TRANSFORMER/dashloader.beta._8._1._21._1.Hyphen.rc._5.mapped.moj._1._21._1@5.1.0-beta.8+1.21.1$Hyphen-0.4.0-rc.5_mapped_moj_1.21.1/dev.notalpha.hyphen.SerializerGenerator.acquireDef(SerializerGenerator.java:140) ~[dashloader-5.1.0-beta.8+1.21.1$Hyphen-0.4.0-rc.5_mapped_moj_1.21.1.jar%234527!/:?] {re:classloading}
at TRANSFORMER/dashloader.beta._8._1._21._1.Hyphen.rc._5.mapped.moj._1._21._1@5.1.0-beta.8+1.21.1$Hyphen-0.4.0-rc.5_mapped_moj_1.21.1/dev.notalpha.hyphen.SerializerGenerator.build(SerializerGenerator.java:188) ~[dashloader-5.1.0-beta.8+1.21.1$Hyphen-0.4.0-rc.5_mapped_moj_1.21.1.jar%234527!/:?] {re:classloading}
at TRANSFORMER/dashloader.beta._8._1._21._1.Hyphen.rc._5.mapped.moj._1._21._1@5.1.0-beta.8+1.21.1$Hyphen-0.4.0-rc.5_mapped_moj_1.21.1/dev.notalpha.hyphen.SerializerFactory.build(SerializerFactory.java:189) ~[dashloader-5.1.0-beta.8+1.21.1$Hyphen-0.4.0-rc.5_mapped_moj_1.21.1.jar%234527!/:?] {re:classloading}
at TRANSFORMER/dashloader@5.1.0-beta.81.21.1/dev.notalpha.dashloader.io.Serializer.<init>(Serializer.java:53) ~[dashloader-5.1.0-beta.8+1.21.1_mapped_moj_1.21.1.jar%234526!/:?] {re:classloading}
at TRANSFORMER/dashloader@5.1.0-beta.81.21.1/dev.notalpha.dashloader.io.RegistrySerializer.<init>(RegistrySerializer.java:44) ~[dashloader-5.1.0-beta.8+1.21.1_mapped_moj_1.21.1.jar%234526!/:?] {re:classloading}
at TRANSFORMER/dashloader@5.1.0-beta.81.21.1/dev.notalpha.dashloader.CacheImpl.<init>(CacheImpl.java:47) ~[dashloader-5.1.0-beta.8+1.21.1_mapped_moj_1.21.1.jar%234526!/:?] {re:classloading}
at TRANSFORMER/dashloader@5.1.0-beta.81.21.1/dev.notalpha.dashloader.CacheFactoryImpl.build(CacheFactoryImpl.java:74) ~[dashloader-5.1.0-beta.8+1.21.1_mapped_moj_1.21.1.jar%234526!/:?] {re:classloading}
at TRANSFORMER/dashloader@5.1.0-beta.81.21.1/dev.notalpha.dashloader.client.DashLoaderClient.<clinit>(DashLoaderClient.java:49) ~[?:?] {re:mixin,re:classloading}
... 19 more```